### PR TITLE
0007: 발로란트 내전 시 팀 나누는 기능 추가

### DIFF
--- a/src/main/kotlin/com/smparkworld/discord/Main.kt
+++ b/src/main/kotlin/com/smparkworld/discord/Main.kt
@@ -16,8 +16,8 @@ fun main(args: Array<String>) {
     }
     val jda = JDABuilder.create(
             token,
-            GatewayIntent.GUILD_MESSAGES,
-            GatewayIntent.DIRECT_MESSAGES, GatewayIntent.GUILD_VOICE_STATES
+            GatewayIntent.MESSAGE_CONTENT,
+            GatewayIntent.DIRECT_MESSAGE_POLLS, GatewayIntent.GUILD_VOICE_STATES, GatewayIntent.GUILD_MEMBERS
         )
         .build()
 

--- a/src/main/kotlin/com/smparkworld/discord/Main.kt
+++ b/src/main/kotlin/com/smparkworld/discord/Main.kt
@@ -17,7 +17,7 @@ fun main(args: Array<String>) {
     val jda = JDABuilder.create(
             token,
             GatewayIntent.MESSAGE_CONTENT,
-            GatewayIntent.DIRECT_MESSAGE_POLLS, GatewayIntent.GUILD_VOICE_STATES, GatewayIntent.GUILD_MEMBERS
+            GatewayIntent.DIRECT_MESSAGE_POLLS, GatewayIntent.GUILD_VOICE_STATES, GatewayIntent.GUILD_MEMBERS, GatewayIntent.GUILD_PRESENCES
         )
         .build()
 

--- a/src/main/kotlin/com/smparkworld/discord/base/StringCode.kt
+++ b/src/main/kotlin/com/smparkworld/discord/base/StringCode.kt
@@ -57,6 +57,9 @@ enum class StringCode(
     VAL_CMD_RANDOM_MAP("val_cmd_random_map"),
     VAL_CMD_RANDOM_MAP_DESC("val_cmd_random_map_desc"),
 
+    VAL_CMD_TEAM("val_cmd_team"),
+    VAL_CMD_TEAM_DESC("val_cmd_team_desc"),
+
     VAL_AGENT("val_agent"),
     VAL_AGENT_TYPE("val_agent_type"),
 
@@ -73,5 +76,16 @@ enum class StringCode(
     VAL_RANDOM_MAP_TITLE("val_random_map_title"),
     VAL_RANDOM_MAP_DESCRIPTION("val_random_map_description"),
     VAL_RANDOM_MAP_TOO_MUCH_IGNORED("val_random_map_too_much_ignored"),
+
+    VAL_TEAM_CANDIDATE_NEED_TO_MORE("val_team_candidate_need_to_more"),
+    VAL_TEAM_CANDIDATE_TOO_MUCH("val_team_candidate_too_much"),
+
+    VAL_TEAM_AUDIO_CHANNEL_NAME_A("val_team_audio_channel_name_a"),
+    VAL_TEAM_AUDIO_CHANNEL_NAME_B("val_team_audio_channel_name_b"),
+
+    VAL_TEAM_RESULT_TITLE("val_team_result_title"),
+    VAL_TEAM_RESULT_DESC("val_team_result_desc"),
+    VAL_TEAM_RESULT_GROUP_A("val_team_result_group_a"),
+    VAL_TEAM_RESULT_GROUP_B("val_team_result_group_b"),
     /* 발로란트 봇 관련 END */
 }

--- a/src/main/kotlin/com/smparkworld/discord/base/StringCode.kt
+++ b/src/main/kotlin/com/smparkworld/discord/base/StringCode.kt
@@ -80,6 +80,7 @@ enum class StringCode(
     VAL_TEAM_CANDIDATE_NEED_TO_MORE("val_team_candidate_need_to_more"),
     VAL_TEAM_CANDIDATE_TOO_MUCH("val_team_candidate_too_much"),
 
+    VAL_TEAM_AUDIO_CHANNEL_NAME("val_team_audio_channel_name"),
     VAL_TEAM_AUDIO_CHANNEL_NAME_A("val_team_audio_channel_name_a"),
     VAL_TEAM_AUDIO_CHANNEL_NAME_B("val_team_audio_channel_name_b"),
 
@@ -87,5 +88,8 @@ enum class StringCode(
     VAL_TEAM_RESULT_DESC("val_team_result_desc"),
     VAL_TEAM_RESULT_GROUP_A("val_team_result_group_a"),
     VAL_TEAM_RESULT_GROUP_B("val_team_result_group_b"),
+
+    VAL_TEAM_FINISH_TITLE("val_team_finish_title"),
+    VAL_TEAM_FINISH_DESC("val_team_finish_desc"),
     /* 발로란트 봇 관련 END */
 }

--- a/src/main/kotlin/com/smparkworld/discord/bot/CommandHandler.kt
+++ b/src/main/kotlin/com/smparkworld/discord/bot/CommandHandler.kt
@@ -1,15 +1,24 @@
 package com.smparkworld.discord.bot
 
+import com.smparkworld.discord.base.StringCode
+import com.smparkworld.discord.base.StringsParser
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.EntitySelectInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent
 
-interface CommandHandler {
+abstract class CommandHandler {
 
-    fun handle(command: String, event: SlashCommandInteractionEvent)
+    fun handleSafely(command: String, event: SlashCommandInteractionEvent) {
+        try {
+            handle(command, event)
+        } catch (e: Exception) {
+            event.reply(StringsParser.getString(StringCode.UNKNOWN_EXCEPTION)).queue()
+        }
+    }
+    protected abstract fun handle(command: String, event: SlashCommandInteractionEvent)
 
-    fun handleInteractionByButton(event: ButtonInteractionEvent) {}
-    fun handleInteractionByStringSelectMenu(event: StringSelectInteractionEvent) {}
-    fun handleInteractionByEntitySelectMenu(event: EntitySelectInteractionEvent) {}
+    open fun handleInteractionByButton(event: ButtonInteractionEvent) {}
+    open fun handleInteractionByStringSelectMenu(event: StringSelectInteractionEvent) {}
+    open fun handleInteractionByEntitySelectMenu(event: EntitySelectInteractionEvent) {}
 }

--- a/src/main/kotlin/com/smparkworld/discord/bot/DiscordBot.kt
+++ b/src/main/kotlin/com/smparkworld/discord/bot/DiscordBot.kt
@@ -20,7 +20,7 @@ abstract class DiscordBot : ListenerAdapter() {
     abstract fun applyCommandData(commandData: SlashCommandData)
 
     open fun onSlashCommand(command: String, event: SlashCommandInteractionEvent) {
-        commandHandlers[event.subcommandName]?.handle(command, event)
+        commandHandlers[event.subcommandName]?.handleSafely(command, event)
     }
 
     override fun onButtonInteraction(event: ButtonInteractionEvent) {

--- a/src/main/kotlin/com/smparkworld/discord/bot/bee/BeeBot.kt
+++ b/src/main/kotlin/com/smparkworld/discord/bot/bee/BeeBot.kt
@@ -4,7 +4,6 @@ import com.smparkworld.discord.base.StringCode
 import com.smparkworld.discord.base.StringsParser.getString
 import com.smparkworld.discord.bot.DiscordBot
 import com.smparkworld.discord.bot.bee.commands.BeeHelpCommandHandler
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
 
@@ -19,9 +18,5 @@ class BeeBot : DiscordBot() {
             // 1. 기능 및 명령어 도움말
             SubcommandData(getString(StringCode.BEE_CMD_HELP), getString(StringCode.BEE_CMD_HELP_DESC)),
         )
-    }
-
-    override fun onSlashCommand(command: String, event: SlashCommandInteractionEvent) {
-        commandHandlers[event.subcommandName]?.handle(command, event)
     }
 }

--- a/src/main/kotlin/com/smparkworld/discord/bot/bee/commands/BeeHelpCommandHandler.kt
+++ b/src/main/kotlin/com/smparkworld/discord/bot/bee/commands/BeeHelpCommandHandler.kt
@@ -8,7 +8,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent
 import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu
 
-class BeeHelpCommandHandler : CommandHandler {
+class BeeHelpCommandHandler : CommandHandler() {
 
     override fun handle(command: String, event: SlashCommandInteractionEvent) {
         val menu = StringSelectMenu.create(COMPONENT_ID)

--- a/src/main/kotlin/com/smparkworld/discord/bot/valorant/ValorantBot.kt
+++ b/src/main/kotlin/com/smparkworld/discord/bot/valorant/ValorantBot.kt
@@ -3,29 +3,29 @@ package com.smparkworld.discord.bot.valorant
 import com.smparkworld.discord.base.StringCode
 import com.smparkworld.discord.base.StringsParser.getString
 import com.smparkworld.discord.bot.DiscordBot
-import com.smparkworld.discord.usecase.GetAudioChannelUsersByEventAuthorUseCase
-import com.smparkworld.discord.usecase.GetAudioChannelUsersByEventAuthorUseCaseImpl
+import com.smparkworld.discord.usecase.GetVoiceChannelUsersByEventAuthorUseCase
+import com.smparkworld.discord.usecase.GetVoiceChannelUsersByEventAuthorUseCaseImpl
 import com.smparkworld.discord.bot.valorant.commands.ValorantRandomMapCommandHandler
 import com.smparkworld.discord.bot.valorant.commands.ValorantRandomPickCommandHandler
 import com.smparkworld.discord.bot.valorant.commands.ValorantRandomPickHardCommandHandler
 import com.smparkworld.discord.bot.valorant.commands.ValorantTeamCommandHandler
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
-import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
-import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent
+import com.smparkworld.discord.usecase.GetVoiceChannelByNameUseCase
+import com.smparkworld.discord.usecase.GetVoiceChannelByNameUseCaseImpl
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
 
 class ValorantBot(
-    getVoiceChannelUsersByMember: GetAudioChannelUsersByEventAuthorUseCase = GetAudioChannelUsersByEventAuthorUseCaseImpl()
+    getVoiceChannelUsersByMember: GetVoiceChannelUsersByEventAuthorUseCase = GetVoiceChannelUsersByEventAuthorUseCaseImpl(),
+    getVoiceChannelByNameUseCase: GetVoiceChannelByNameUseCase = GetVoiceChannelByNameUseCaseImpl()
 ) : DiscordBot() {
 
     override val commandHandlers = mapOf(
         getString(StringCode.VAL_CMD_RANDOM_PICK) to ValorantRandomPickCommandHandler(getVoiceChannelUsersByMember),
         getString(StringCode.VAL_CMD_RANDOM_PICK_HARD) to ValorantRandomPickHardCommandHandler(getVoiceChannelUsersByMember),
         getString(StringCode.VAL_CMD_RANDOM_MAP) to ValorantRandomMapCommandHandler(getVoiceChannelUsersByMember),
-        getString(StringCode.VAL_CMD_TEAM) to ValorantTeamCommandHandler(getVoiceChannelUsersByMember)
+        getString(StringCode.VAL_CMD_TEAM) to ValorantTeamCommandHandler(getVoiceChannelUsersByMember, getVoiceChannelByNameUseCase)
     )
 
     override fun applyCommandData(commandData: SlashCommandData) {

--- a/src/main/kotlin/com/smparkworld/discord/bot/valorant/ValorantBot.kt
+++ b/src/main/kotlin/com/smparkworld/discord/bot/valorant/ValorantBot.kt
@@ -8,6 +8,7 @@ import com.smparkworld.discord.usecase.GetAudioChannelUsersByEventAuthorUseCaseI
 import com.smparkworld.discord.bot.valorant.commands.ValorantRandomMapCommandHandler
 import com.smparkworld.discord.bot.valorant.commands.ValorantRandomPickCommandHandler
 import com.smparkworld.discord.bot.valorant.commands.ValorantRandomPickHardCommandHandler
+import com.smparkworld.discord.bot.valorant.commands.ValorantTeamCommandHandler
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent
@@ -23,7 +24,8 @@ class ValorantBot(
     override val commandHandlers = mapOf(
         getString(StringCode.VAL_CMD_RANDOM_PICK) to ValorantRandomPickCommandHandler(getVoiceChannelUsersByMember),
         getString(StringCode.VAL_CMD_RANDOM_PICK_HARD) to ValorantRandomPickHardCommandHandler(getVoiceChannelUsersByMember),
-        getString(StringCode.VAL_CMD_RANDOM_MAP) to ValorantRandomMapCommandHandler(getVoiceChannelUsersByMember)
+        getString(StringCode.VAL_CMD_RANDOM_MAP) to ValorantRandomMapCommandHandler(getVoiceChannelUsersByMember),
+        getString(StringCode.VAL_CMD_TEAM) to ValorantTeamCommandHandler(getVoiceChannelUsersByMember)
     )
 
     override fun applyCommandData(commandData: SlashCommandData) {
@@ -56,6 +58,14 @@ class ValorantBot(
                     OptionData(OptionType.STRING, getString(StringCode.IGNORE7), getString(StringCode.IGNORE_MAP_DESC), false).also(::applyIgnoreMapChoices),
                     OptionData(OptionType.STRING, getString(StringCode.IGNORE8), getString(StringCode.IGNORE_MAP_DESC), false).also(::applyIgnoreMapChoices),
                 ),
+
+            // 4. 팀 만들기
+            SubcommandData(getString(StringCode.VAL_CMD_TEAM), getString(StringCode.VAL_CMD_TEAM_DESC))
+                .addOption(OptionType.USER, getString(StringCode.IGNORE1), getString(StringCode.IGNORE_USER_DESC), false)
+                .addOption(OptionType.USER, getString(StringCode.IGNORE2), getString(StringCode.IGNORE_USER_DESC), false)
+                .addOption(OptionType.USER, getString(StringCode.IGNORE3), getString(StringCode.IGNORE_USER_DESC), false)
+                .addOption(OptionType.USER, getString(StringCode.IGNORE4), getString(StringCode.IGNORE_USER_DESC), false)
+                .addOption(OptionType.USER, getString(StringCode.IGNORE5), getString(StringCode.IGNORE_USER_DESC), false),
         )
     }
 

--- a/src/main/kotlin/com/smparkworld/discord/bot/valorant/commands/ValorantRandomMapCommandHandler.kt
+++ b/src/main/kotlin/com/smparkworld/discord/bot/valorant/commands/ValorantRandomMapCommandHandler.kt
@@ -12,7 +12,7 @@ import java.util.*
 
 class ValorantRandomMapCommandHandler(
     private val getVoiceChannelUsersByMember: GetAudioChannelUsersByEventAuthorUseCase
-) : CommandHandler {
+) : CommandHandler() {
 
     override fun handle(command: String, event: SlashCommandInteractionEvent) {
         checkAudioChannelValidation(event) {

--- a/src/main/kotlin/com/smparkworld/discord/bot/valorant/commands/ValorantRandomMapCommandHandler.kt
+++ b/src/main/kotlin/com/smparkworld/discord/bot/valorant/commands/ValorantRandomMapCommandHandler.kt
@@ -3,7 +3,7 @@ package com.smparkworld.discord.bot.valorant.commands
 import com.smparkworld.discord.base.StringCode
 import com.smparkworld.discord.base.StringsParser.getString
 import com.smparkworld.discord.bot.CommandHandler
-import com.smparkworld.discord.usecase.GetAudioChannelUsersByEventAuthorUseCase
+import com.smparkworld.discord.usecase.GetVoiceChannelUsersByEventAuthorUseCase
 import com.smparkworld.discord.bot.valorant.ValorantMapType
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.Member
@@ -11,7 +11,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import java.util.*
 
 class ValorantRandomMapCommandHandler(
-    private val getVoiceChannelUsersByMember: GetAudioChannelUsersByEventAuthorUseCase
+    private val getVoiceChannelUsersByMember: GetVoiceChannelUsersByEventAuthorUseCase
 ) : CommandHandler() {
 
     override fun handle(command: String, event: SlashCommandInteractionEvent) {
@@ -61,13 +61,13 @@ class ValorantRandomMapCommandHandler(
         perform: (members: List<Member>) -> Unit
     ) {
         when (val result = getVoiceChannelUsersByMember(event)) {
-            is GetAudioChannelUsersByEventAuthorUseCase.Result.Success -> {
+            is GetVoiceChannelUsersByEventAuthorUseCase.Result.Success -> {
                 perform.invoke(result.members)
             }
-            is GetAudioChannelUsersByEventAuthorUseCase.Result.NotInVoiceChannel -> {
+            is GetVoiceChannelUsersByEventAuthorUseCase.Result.NotInVoiceChannel -> {
                 event.reply(getString(StringCode.VAL_ABSENT_COMMAND_AUTHOR)).queue()
             }
-            is GetAudioChannelUsersByEventAuthorUseCase.Result.Error -> {
+            is GetVoiceChannelUsersByEventAuthorUseCase.Result.Error -> {
                 event.reply(getString(StringCode.UNKNOWN_EXCEPTION)).queue()
             }
         }

--- a/src/main/kotlin/com/smparkworld/discord/bot/valorant/commands/ValorantRandomPickCommandHandler.kt
+++ b/src/main/kotlin/com/smparkworld/discord/bot/valorant/commands/ValorantRandomPickCommandHandler.kt
@@ -3,7 +3,7 @@ package com.smparkworld.discord.bot.valorant.commands
 import com.smparkworld.discord.base.StringCode
 import com.smparkworld.discord.base.StringsParser.getString
 import com.smparkworld.discord.bot.CommandHandler
-import com.smparkworld.discord.usecase.GetAudioChannelUsersByEventAuthorUseCase
+import com.smparkworld.discord.usecase.GetVoiceChannelUsersByEventAuthorUseCase
 import com.smparkworld.discord.bot.valorant.ValorantAgentType
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.Member
@@ -12,7 +12,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import java.util.*
 
 class ValorantRandomPickCommandHandler(
-    private val getVoiceChannelUsersByMember: GetAudioChannelUsersByEventAuthorUseCase
+    private val getVoiceChannelUsersByMember: GetVoiceChannelUsersByEventAuthorUseCase
 ) : CommandHandler() {
 
     override fun handle(command: String, event: SlashCommandInteractionEvent) {
@@ -63,13 +63,13 @@ class ValorantRandomPickCommandHandler(
         perform: (members: List<Member>) -> Unit
     ) {
         when (val result = getVoiceChannelUsersByMember(event)) {
-            is GetAudioChannelUsersByEventAuthorUseCase.Result.Success -> {
+            is GetVoiceChannelUsersByEventAuthorUseCase.Result.Success -> {
                 perform.invoke(result.members)
             }
-            is GetAudioChannelUsersByEventAuthorUseCase.Result.NotInVoiceChannel -> {
+            is GetVoiceChannelUsersByEventAuthorUseCase.Result.NotInVoiceChannel -> {
                 event.reply(getString(StringCode.VAL_ABSENT_COMMAND_AUTHOR)).queue()
             }
-            is GetAudioChannelUsersByEventAuthorUseCase.Result.Error -> {
+            is GetVoiceChannelUsersByEventAuthorUseCase.Result.Error -> {
                 event.reply(getString(StringCode.UNKNOWN_EXCEPTION)).queue()
             }
         }

--- a/src/main/kotlin/com/smparkworld/discord/bot/valorant/commands/ValorantRandomPickHardCommandHandler.kt
+++ b/src/main/kotlin/com/smparkworld/discord/bot/valorant/commands/ValorantRandomPickHardCommandHandler.kt
@@ -3,7 +3,7 @@ package com.smparkworld.discord.bot.valorant.commands
 import com.smparkworld.discord.base.StringCode
 import com.smparkworld.discord.base.StringsParser.getString
 import com.smparkworld.discord.bot.CommandHandler
-import com.smparkworld.discord.usecase.GetAudioChannelUsersByEventAuthorUseCase
+import com.smparkworld.discord.usecase.GetVoiceChannelUsersByEventAuthorUseCase
 import com.smparkworld.discord.bot.valorant.ValorantAgentType
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.Member
@@ -12,7 +12,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import java.util.*
 
 class ValorantRandomPickHardCommandHandler(
-    private val getVoiceChannelUsersByMember: GetAudioChannelUsersByEventAuthorUseCase
+    private val getVoiceChannelUsersByMember: GetVoiceChannelUsersByEventAuthorUseCase
 ) : CommandHandler() {
 
     override fun handle(command: String, event: SlashCommandInteractionEvent) {
@@ -71,13 +71,13 @@ class ValorantRandomPickHardCommandHandler(
         perform: (members: List<Member>) -> Unit
     ) {
         when (val result = getVoiceChannelUsersByMember(event)) {
-            is GetAudioChannelUsersByEventAuthorUseCase.Result.Success -> {
+            is GetVoiceChannelUsersByEventAuthorUseCase.Result.Success -> {
                 perform.invoke(result.members)
             }
-            is GetAudioChannelUsersByEventAuthorUseCase.Result.NotInVoiceChannel -> {
+            is GetVoiceChannelUsersByEventAuthorUseCase.Result.NotInVoiceChannel -> {
                 event.reply(getString(StringCode.VAL_ABSENT_COMMAND_AUTHOR)).queue()
             }
-            is GetAudioChannelUsersByEventAuthorUseCase.Result.Error -> {
+            is GetVoiceChannelUsersByEventAuthorUseCase.Result.Error -> {
                 event.reply(getString(StringCode.UNKNOWN_EXCEPTION)).queue()
             }
         }

--- a/src/main/kotlin/com/smparkworld/discord/bot/valorant/commands/ValorantRandomPickHardCommandHandler.kt
+++ b/src/main/kotlin/com/smparkworld/discord/bot/valorant/commands/ValorantRandomPickHardCommandHandler.kt
@@ -13,7 +13,7 @@ import java.util.*
 
 class ValorantRandomPickHardCommandHandler(
     private val getVoiceChannelUsersByMember: GetAudioChannelUsersByEventAuthorUseCase
-) : CommandHandler {
+) : CommandHandler() {
 
     override fun handle(command: String, event: SlashCommandInteractionEvent) {
         checkAudioChannelValidation(event) { members ->

--- a/src/main/kotlin/com/smparkworld/discord/bot/valorant/commands/ValorantTeamCommandHandler.kt
+++ b/src/main/kotlin/com/smparkworld/discord/bot/valorant/commands/ValorantTeamCommandHandler.kt
@@ -3,15 +3,23 @@ package com.smparkworld.discord.bot.valorant.commands
 import com.smparkworld.discord.base.StringCode
 import com.smparkworld.discord.base.StringsParser.getString
 import com.smparkworld.discord.bot.CommandHandler
-import com.smparkworld.discord.usecase.GetAudioChannelUsersByEventAuthorUseCase
+import com.smparkworld.discord.usecase.GetVoiceChannelByNameUseCase
+import com.smparkworld.discord.usecase.GetVoiceChannelUsersByEventAuthorUseCase
 import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
-import java.util.Collections
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.interactions.components.buttons.Button
+import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
 
 class ValorantTeamCommandHandler(
-    private val getVoiceChannelUsersByMember: GetAudioChannelUsersByEventAuthorUseCase
+    private val getVoiceChannelUsersByMember: GetVoiceChannelUsersByEventAuthorUseCase,
+    private val getVoiceChannelByNameUseCase: GetVoiceChannelByNameUseCase
 ) : CommandHandler() {
 
     override fun handle(command: String, event: SlashCommandInteractionEvent) {
@@ -30,34 +38,65 @@ class ValorantTeamCommandHandler(
                     .let(::splitList)
 
                 val playerGroupANames = StringBuilder()
-                    .also { builder -> players.forEach { builder.append("${it.user.globalName ?: it.user.name }\n") } }
+                    .also { builder -> playerGroupA.forEach { builder.append("${it.user.globalName ?: it.user.name }\n") } }
                     .toString()
 
                 val playerGroupBNames = StringBuilder()
-                    .also { builder -> players.forEach { builder.append("${it.user.globalName ?: it.user.name }\n") } }
+                    .also { builder -> playerGroupB.forEach { builder.append("${it.user.globalName ?: it.user.name }\n") } }
                     .toString()
 
-                // 2. 두 개의 새로운 음성 채널 생성 및 팀원 이동
-                guild.createVoiceChannel(getString(StringCode.VAL_TEAM_AUDIO_CHANNEL_NAME_A)).queue { channel ->
-                    playerGroupA.forEach { player ->
-                        guild.moveVoiceMember(player, channel).queue()
+                // 2. 기본 음성 채널과 두 개의 새로운 음성 채널 생성 및 팀원 이동
+                getVoiceChannelByNameUseCase(guild, getString(StringCode.VAL_TEAM_AUDIO_CHANNEL_NAME)) {
+                    getVoiceChannelByNameUseCase(guild, getString(StringCode.VAL_TEAM_AUDIO_CHANNEL_NAME_A)) { channel ->
+                        playerGroupA.forEach { player ->
+                            guild.moveVoiceMember(player, channel).queue()
+                        }
                     }
-                }
-                guild.createVoiceChannel(getString(StringCode.VAL_TEAM_AUDIO_CHANNEL_NAME_B)).queue {channel ->
-                    playerGroupB.forEach { player ->
-                        guild.moveVoiceMember(player, channel).queue()
+                    getVoiceChannelByNameUseCase(guild, getString(StringCode.VAL_TEAM_AUDIO_CHANNEL_NAME_B)) { channel ->
+                        playerGroupB.forEach { player ->
+                            guild.moveVoiceMember(player, channel).queue()
+                        }
                     }
                 }
 
+                // 3. 결과 메세지 전송
                 val message = EmbedBuilder()
                     .setTitle(getString(StringCode.VAL_TEAM_RESULT_TITLE))
                     .setDescription(getString(StringCode.VAL_TEAM_RESULT_DESC))
+                    .addBlankField(false)
                     .addField(getString(StringCode.VAL_TEAM_RESULT_GROUP_A), playerGroupANames, true)
                     .addField(getString(StringCode.VAL_TEAM_RESULT_GROUP_B), playerGroupBNames, true)
                     .build()
-                event.replyEmbeds(message).queue()
+
+                event.replyEmbeds(message)
+                    .setActionRow(Button.primary(COMPONENT_ID, "내전 종료하기"))
+                    .queue()
             }
         }
+    }
+
+    override fun handleInteractionByButton(event: ButtonInteractionEvent) {
+        if (event.componentId != COMPONENT_ID) return
+
+        event.guild?.let { guild ->
+            getVoiceChannelByNameUseCase(guild, getString(StringCode.VAL_TEAM_AUDIO_CHANNEL_NAME)) { defaultChannel ->
+                getVoiceChannelByNameUseCase(guild, getString(StringCode.VAL_TEAM_AUDIO_CHANNEL_NAME_A)) { channel ->
+                    moveChannelUsersWithDeleting(guild, from = channel, to = defaultChannel)
+                }
+                getVoiceChannelByNameUseCase(guild, getString(StringCode.VAL_TEAM_AUDIO_CHANNEL_NAME_B)) { channel ->
+                    moveChannelUsersWithDeleting(guild, from = channel, to = defaultChannel)
+                }
+            }
+        }
+
+        val finishAuthor = event.member?.user?.globalName
+            ?: event.member?.user?.name
+
+        val message = EmbedBuilder()
+            .setTitle(getString(StringCode.VAL_TEAM_FINISH_TITLE))
+            .setDescription(getString(StringCode.VAL_TEAM_FINISH_DESC, finishAuthor.toString()))
+            .build()
+        event.replyEmbeds(message).queue()
     }
 
     private fun checkAudioChannelValidation(
@@ -65,13 +104,13 @@ class ValorantTeamCommandHandler(
         perform: (members: List<Member>) -> Unit
     ) {
         when (val result = getVoiceChannelUsersByMember(event)) {
-            is GetAudioChannelUsersByEventAuthorUseCase.Result.Success -> {
+            is GetVoiceChannelUsersByEventAuthorUseCase.Result.Success -> {
                 perform.invoke(result.members)
             }
-            is GetAudioChannelUsersByEventAuthorUseCase.Result.NotInVoiceChannel -> {
+            is GetVoiceChannelUsersByEventAuthorUseCase.Result.NotInVoiceChannel -> {
                 event.reply(getString(StringCode.VAL_ABSENT_COMMAND_AUTHOR)).queue()
             }
-            is GetAudioChannelUsersByEventAuthorUseCase.Result.Error -> {
+            is GetVoiceChannelUsersByEventAuthorUseCase.Result.Error -> {
                 event.reply(getString(StringCode.UNKNOWN_EXCEPTION)).queue()
             }
         }
@@ -115,5 +154,20 @@ class ValorantTeamCommandHandler(
         val firstHalf = list.take(midpoint)
         val secondHalf = list.drop(midpoint)
         return Pair(firstHalf, secondHalf)
+    }
+
+    private fun moveChannelUsersWithDeleting(guild: Guild, from: VoiceChannel, to: VoiceChannel) {
+        val latch = CountDownLatch(from.members.size)
+        from.members.forEach { player ->
+            guild.moveVoiceMember(player, to).queue { latch.countDown() }
+        }
+        Thread {
+            latch.await()
+            from.delete().queue()
+        }.start()
+    }
+
+    companion object {
+        private const val COMPONENT_ID = "button:finish"
     }
 }

--- a/src/main/kotlin/com/smparkworld/discord/usecase/GetAudioChannelByChannelNameUseCase.kt
+++ b/src/main/kotlin/com/smparkworld/discord/usecase/GetAudioChannelByChannelNameUseCase.kt
@@ -1,0 +1,42 @@
+package com.smparkworld.discord.usecase
+
+import com.smparkworld.discord.usecase.GetVoiceChannelByNameUseCase.Result
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
+
+interface GetVoiceChannelByNameUseCase {
+
+    operator fun invoke(
+        guild: Guild,
+        channelName: String,
+        perform: (channel: VoiceChannel) -> Unit
+    ): Result
+
+    sealed interface Result {
+
+        data class Error(
+            val exception: Exception
+        ) : Result
+
+        object Success : Result
+    }
+}
+
+class GetVoiceChannelByNameUseCaseImpl : GetVoiceChannelByNameUseCase {
+
+    override operator fun invoke(
+        guild: Guild,
+        channelName: String,
+        perform: (channel: VoiceChannel) -> Unit
+    ): Result = try {
+        val channel = guild.voiceChannels.find { it.name == channelName }
+        if (channel != null) {
+            perform.invoke(channel)
+        } else {
+            guild.createVoiceChannel(channelName).queue(perform)
+        }
+        Result.Success
+    } catch (e: Exception) {
+        Result.Error(e)
+    }
+}

--- a/src/main/kotlin/com/smparkworld/discord/usecase/GetVoiceChannelUsersByEventAuthorUseCase.kt
+++ b/src/main/kotlin/com/smparkworld/discord/usecase/GetVoiceChannelUsersByEventAuthorUseCase.kt
@@ -1,10 +1,10 @@
 package com.smparkworld.discord.usecase
 
-import com.smparkworld.discord.usecase.GetAudioChannelUsersByEventAuthorUseCase.Result
+import com.smparkworld.discord.usecase.GetVoiceChannelUsersByEventAuthorUseCase.Result
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.interactions.Interaction
 
-interface GetAudioChannelUsersByEventAuthorUseCase {
+interface GetVoiceChannelUsersByEventAuthorUseCase {
 
     operator fun invoke(event: Interaction): Result
 
@@ -22,7 +22,7 @@ interface GetAudioChannelUsersByEventAuthorUseCase {
     }
 }
 
-class GetAudioChannelUsersByEventAuthorUseCaseImpl : GetAudioChannelUsersByEventAuthorUseCase {
+class GetVoiceChannelUsersByEventAuthorUseCaseImpl : GetVoiceChannelUsersByEventAuthorUseCase {
 
     override operator fun invoke(event: Interaction): Result = try {
         val member = event.member

--- a/src/main/resources/strings-kor.xml
+++ b/src/main/resources/strings-kor.xml
@@ -53,7 +53,7 @@
     <string name="val_cmd_random_map">랜덤픽-맵</string>
     <string name="val_cmd_random_map_desc">발로란트에 존재하는 맵 중 하나를 추천합니다.</string>
 
-    <string name="val_cmd_team">팀 만들기</string>
+    <string name="val_cmd_team">팀_만들기</string>
     <string name="val_cmd_team_desc">음성 채널에 있는 유저들을 무작위로 두 개의 팀으로 나누어 각 팀의 새로운 음성 채널로 보냅니다.</string>
 
     <string name="val_agent">에이전트</string>
@@ -73,16 +73,20 @@
     <string name="val_random_map_description">발로란트에 존재하는 맵 중 하나를 추천합니다.</string>
     <string name="val_random_map_too_much_ignored">맵을 너무 많이 제외시켰어요. 다시 조정해주세요.</string>
 
-    <string name="val_team_candidate_need_to_more">팀 생성하기 위한 플레이어가 부족해요! 제외된 유저를 다시 조정해주세요.</string>
+    <string name="val_team_candidate_need_to_more">팀 생성하기 위한 플레이어가 부족해요. 최소 2명 이상의 플레이어가 필요합니다!</string>
     <string name="val_team_candidate_too_much">채널에 있는 유저가 10명을 초과해요! 최대 10명이 되도록 일부 유저를 제외해주세요.</string>
 
+    <string name="val_team_audio_channel_name">발로란트 내전 채널</string>
     <string name="val_team_audio_channel_name_a">발로란트 내전 A팀 (수비)</string>
     <string name="val_team_audio_channel_name_b">발로란트 내전 B팀 (공격)</string>
 
     <string name="val_team_result_title">발로란트 내전 팀 생성</string>
-    <string name="val_team_result_desc">음성 채널에 있는 유저들을 두 개의 팀으로 나누어 각 팀의 음성 채널로 보내드렸어요.\n새로운 팀원을 믿으세요! Good Luck-!</string>
+    <string name="val_team_result_desc">음성 채널에 있는 유저들을 두 개의 팀 음성 채널로 보내드렸어요.\n내전이 종료된 후에 아래의 버튼을 클릭하면 생성된 채널을 정리하고 한 채널로 모아드릴게요!\n\n맵도 랜덤으로 선택할 수 있는 명령어가 있으니 참고해주세요 : )\nGood Luck-!</string>
     <string name="val_team_result_group_a">A팀 (수비)</string>
     <string name="val_team_result_group_b">B팀 (수비)</string>
+
+    <string name="val_team_finish_title">발로란트 내전 종료</string>
+    <string name="val_team_finish_desc">%s님에 의해 발로란트 내전이 종료되었어요.\n각 팀의 채널을 제거하고 플레이어들을 모아드렸습니다.</string>
     <!-- 발로란트 봇 관련 END -->
 
 </resources>

--- a/src/main/resources/strings-kor.xml
+++ b/src/main/resources/strings-kor.xml
@@ -53,6 +53,9 @@
     <string name="val_cmd_random_map">랜덤픽-맵</string>
     <string name="val_cmd_random_map_desc">발로란트에 존재하는 맵 중 하나를 추천합니다.</string>
 
+    <string name="val_cmd_team">팀 만들기</string>
+    <string name="val_cmd_team_desc">음성 채널에 있는 유저들을 무작위로 두 개의 팀으로 나누어 각 팀의 새로운 음성 채널로 보냅니다.</string>
+
     <string name="val_agent">에이전트</string>
     <string name="val_agent_type">역할군</string>
 
@@ -69,6 +72,17 @@
     <string name="val_random_map_title">발로란트 맵 랜덤픽</string>
     <string name="val_random_map_description">발로란트에 존재하는 맵 중 하나를 추천합니다.</string>
     <string name="val_random_map_too_much_ignored">맵을 너무 많이 제외시켰어요. 다시 조정해주세요.</string>
+
+    <string name="val_team_candidate_need_to_more">팀 생성하기 위한 플레이어가 부족해요! 제외된 유저를 다시 조정해주세요.</string>
+    <string name="val_team_candidate_too_much">채널에 있는 유저가 10명을 초과해요! 최대 10명이 되도록 일부 유저를 제외해주세요.</string>
+
+    <string name="val_team_audio_channel_name_a">발로란트 내전 A팀 (수비)</string>
+    <string name="val_team_audio_channel_name_b">발로란트 내전 B팀 (공격)</string>
+
+    <string name="val_team_result_title">발로란트 내전 팀 생성</string>
+    <string name="val_team_result_desc">음성 채널에 있는 유저들을 두 개의 팀으로 나누어 각 팀의 음성 채널로 보내드렸어요.\n새로운 팀원을 믿으세요! Good Luck-!</string>
+    <string name="val_team_result_group_a">A팀 (수비)</string>
+    <string name="val_team_result_group_b">B팀 (수비)</string>
     <!-- 발로란트 봇 관련 END -->
 
 </resources>


### PR DESCRIPTION
## 🌟 작업 상세
발로란트 게임으로 내전할 때 팀을 나눠주는 기능을 추가합니다.

## 🌟 주요 변경점
- 디스코드의 봇 GatewayIntent 변경
- 채널 생성 기능 추가

## 🌟 참고 자료
- Issue ticket : https://github.com/Park-SM/discord-bot-bee/issues/7