### PR TITLE
0018: Youtube signature cipher 업데이트 및 Error 로그 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
 
     implementation("net.dv8tion:JDA:5.1.2")
     implementation("dev.arbjerg:lavaplayer:2.2.3")
-    implementation("dev.lavalink.youtube:common:1.11.4")
+    implementation("dev.lavalink.youtube:common:1.12.0")
 
     testImplementation(kotlin("test"))
 }

--- a/src/main/kotlin/com/smparkworld/discord/core/logger/Logger.kt
+++ b/src/main/kotlin/com/smparkworld/discord/core/logger/Logger.kt
@@ -10,6 +10,7 @@ object Logger {
     private const val INFO = "[INFO]"
     private const val DEBUG = "[DEBUG]"
     private const val SYSTEM = "[SYSTEM]"
+    private const val ERROR = "[ERROR]"
 
     private val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
     private val currentTimestamp: String
@@ -25,6 +26,11 @@ object Logger {
 
     fun s(tag: String, message: String) {
         println("$currentTimestamp ${formatCategory(SYSTEM)} ${formatTag(tag)} $message")
+    }
+
+    fun e(tag: String, message: String, exception: Exception? = null) {
+        println("$currentTimestamp ${formatCategory(ERROR)} ${formatTag(tag)} $message")
+        exception?.printStackTrace()
     }
 
     private fun formatTag(input: String): String {

--- a/src/main/kotlin/com/smparkworld/discord/core/media/GuildMusicManager.kt
+++ b/src/main/kotlin/com/smparkworld/discord/core/media/GuildMusicManager.kt
@@ -3,9 +3,11 @@ package com.smparkworld.discord.core.media
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
 import com.sedmelluq.discord.lavaplayer.player.event.AudioEventAdapter
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason
 import com.sedmelluq.discord.lavaplayer.track.playback.MutableAudioFrame
+import com.smparkworld.discord.core.logger.Logger
 import com.smparkworld.discord.core.media.MusicManagerMediator.offerTrackHistory
 import com.smparkworld.discord.core.media.extensions.loadItem
 import com.smparkworld.discord.core.media.model.LavaPlayerTrackImpl
@@ -39,6 +41,9 @@ class GuildMusicManager internal constructor(
 
     init {
         val listener = object : AudioEventAdapter() {
+            override fun onTrackException(player: AudioPlayer?, track: AudioTrack?, exception: FriendlyException?) {
+                Logger.e(TAG, "An exception occurred while processing the track.", exception)
+            }
             override fun onTrackEnd(player: AudioPlayer?, track: AudioTrack?, endReason: AudioTrackEndReason) {
                 if (endReason.mayStartNext) { nextTrack() }
             }
@@ -126,6 +131,8 @@ class GuildMusicManager internal constructor(
     }
 
     companion object {
+        private const val TAG = "GuildMusicManager"
+
         private const val SEARCH_PREFIX = "ytsearch"
         private const val YOUTUBE_URL_PREFIX_1 = "https://youtube.com/"
         private const val YOUTUBE_URL_PREFIX_2 = "https://www.youtube.com/"


### PR DESCRIPTION
## 🌟 작업 상세
`/꿀벌 재생` 입력 후 노래 예약 시 검색은 되지만 음악 재생이 되지 않는 이슈 발생.

원인은, 최근 YouTube에서 signatureCipher Javascript 구조를 변경 후 배포한 것으로 보임.

그래서 YouTube 검색까지는 정상 동작하지만, 실제 검색한 Track의 스트림이 열리지 않았던 것으로 파악했고, 이를 대응하는 Lavalink의 common 모듈 업데이트 진행

추후 모니터링을 위해, 위와 같이 exception 발생 시 error logging 로직 추가.

## 🌟 주요 변경점

- lavalink의 youtube-common 라이브러리 버전업
  - https://github.com/lavalink-devs/youtube-source/releases/tag/1.12.0
- monitoring을 위한 에러 로그 추가 

## 🌟 참고 자료
- Issue ticket : https://github.com/Park-SM/discord-bot-bee/issues/18